### PR TITLE
smaller text/icons for more consistency (nav drawer)

### DIFF
--- a/app/src/main/res/layout/custom_nav_drawer_row.xml
+++ b/app/src/main/res/layout/custom_nav_drawer_row.xml
@@ -7,13 +7,13 @@
         android:layout_marginTop="5dp"
         android:layout_marginBottom="5dp"
         android:layout_marginLeft="5dp"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:id="@+id/imageView"/>
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:textAppearance="?android:attr/textAppearanceMedium"
         android:id="@+id/textView"
         android:layout_gravity="center"
         android:gravity="center"/>


### PR DESCRIPTION
Smaller text/icons in nav drawer (cuz the old ones were too big).